### PR TITLE
WIP: ArgoCD Bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you would also like to deploy ArgoCD as part of your bootstrapping, apply the
 
 ```sh
 helm dep up bootstrap
-helm install open-management-portal bootstrap/ -f <values-file-containing-secrets-data> --set application.ref=<desired git ref>
+helm install open-management-portal bootstrap/ -f <values-file-containing-secrets-data> --set application.ref=<desired git ref> --set argo-cd.enabled=true
 ```
 
 **Note:** For obvious reasons, you likely want to store your values file containing your secrets in a seperate, secure repository.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,20 @@ This repository both bootstraps and manages the deployment lifecycle of the Open
 To create an instance of the Open Management Portal in a cluster, apply the `bootstrap` Helm chart using the following command:
 
 ```sh
+helm dep up bootstrap
 helm install open-management-portal bootstrap/ --set application.ref=<desired git ref>
 ```
+
+If you would also like to deploy ArgoCD as part of your bootstrapping, apply the `bootstrap` Helm chart using the following command:
+
+```sh
+helm dep up bootstrap
+helm install open-management-portal bootstrap/ -f <values-file-containing-secrets-data> --set application.ref=<desired git ref>
+```
+
+**Note:** For obvious reasons, you likely want to store your values file containing your secrets in a seperate, secure repository.
+
+An example of a values file that contains the appropriate ArgoCD secrets data can be found [here](bootstrap/values-secrets-example.yaml). 
 
 Make sure to replace `<desired-git-ref>` with the tag that you want to deploy to this cluster. If this is a staging cluster, you might have a Git tag such as `deploy-staging`; and if this is a production cluster, maybe `deploy-production`.
 

--- a/bootstrap/.gitignore
+++ b/bootstrap/.gitignore
@@ -1,0 +1,2 @@
+requirements.lock
+charts/*

--- a/bootstrap/requirements.yaml
+++ b/bootstrap/requirements.yaml
@@ -1,0 +1,5 @@
+dependencies:
+- name: argo-cd
+  version: "2.0.3"
+  repository: "https://tylerauerbeck.github.io/argo-helm"
+  condition: argo-cd.enabled

--- a/bootstrap/values-secrets-example.yaml
+++ b/bootstrap/values-secrets-example.yaml
@@ -1,0 +1,25 @@
+argo-cd:
+  server:
+    config:
+      repository.credentials: |
+        - sshPrivateKeySecret:
+            key: sshPrivateKey
+            name: name-of-my-secret
+          url: ssh://git@github.com/myorg/myrepo
+
+  configs:
+    knownHosts:
+      data:
+        ssh_known_hosts: |
+          bitbucket.org ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==
+          github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
+          gitlab.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFSMqzJeV9rUzU4kWitGjeR4PWSa29SPqJ1fVkhtj3Hw9xjLVXVYrU9QlYWrOLXBpQ6KWjbjTDTdDkoohFzgbEY=
+          gitlab.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf
+          gitlab.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsj2bNKTBSpIYDEGk9KxsGh3mySTRgMtXL583qmBpzeQ+jqCMRgBqB98u3z++J1sKlXHWfM9dyhSevkMwSbhoR8XIq/U0tCNyokEi/ueaBMCvbcTHhO7FcwzY92WK4Yt0aGROY5qX2UKSeOvuP4D6TPqKF1onrSzH9bx9XUf2lEdWT/ia1NEKjunUqu1xOB/StKDHMoX4/OKyIzuS0q/T1zOATthvasJFoPrAjkohTyaDUz2LN5JoH839hViyEG82yB+MjcFV5MU3N1l1QL3cVUCh93xSaua1N85qivl+siMkPGbO5xR/En4iEY6K2XPASUEMaieWVNTRCtJ4S8H+9
+          ssh.dev.azure.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4NakVyIzf1rXYd4d7wo6jBlkLvCA4odBlL0mDUyZ0/QUfTTqeu+tm22gOsv+VrVTMk6vwRU75gY/y9ut5Mb3bR5BV58dKXyq9A9UeB5Cakehn5Zgm6x1mKoVyf+FFn26iYqXJRgzIZZcZ5V6hrE0Qg39kZm4az48o0AUbf6Sp4SLdvnuMa2sVNwHBboS7EJkm57XQPVU3/QpyNLHbWDdzwtrlS+ez30S3AdYhLKEOxAG8weOnyrtLJAUen9mTkol8oII1edf7mWWbWVf0nBmly21+nZcmCTISQBtdcyPaEno7fFQMDD26/s0lfKob4Kw8H
+          vs-ssh.visualstudio.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7Hr1oTWqNqOlzGJOfGJ4NakVyIzf1rXYd4d7wo6jBlkLvCA4odBlL0mDUyZ0/QUfTTqeu+tm22gOsv+VrVTMk6vwRU75gY/y9ut5Mb3bR5BV58dKXyq9A9UeB5Cakehn5Zgm6x1mKoVyf+FFn26iYqXJRgzIZZcZ5V6hrE0Qg39kZm4az48o0AUbf6Sp4SLdvnuMa2sVNwHBboS7EJkm57XQPVU3/QpyNLHbWDdzwtrlS+ez30S3AdYhLKEOxAG8weOnyrtLJAUen9mTkol8oII1edf7mWWbWVf0nBmly21+nZcmCTISQBtdcyPaEno7fFQMDD26/s0lfKob4Kw8H
+
+    secret:
+      createSecret: true
+      argocdServerAdminPassword: <some-bcrypt-hashed-secret>
+      # `htpasswd -nbBC 10 "" $ARGO_PWD | tr -d ':\n' | sed 's/$2y/$2a/'`

--- a/bootstrap/values.yaml
+++ b/bootstrap/values.yaml
@@ -6,3 +6,28 @@ application:
   url: https://github.com/rht-labs/open-management-portal-deployment.git
   path: applications/
   ref: master
+
+argo-cd:
+  enabled: false
+  installCRDs: false 
+
+  global:
+# Do we want this?
+    clusterAdminAccess:
+      enabled: true 
+
+  dex:
+    image:
+      tag: v2.22.0
+
+  server:
+    extraArgs:
+    - --insecure
+
+    route:
+      enabled: true
+      termination_type: edge
+      termination_policy: Redirect
+
+  openshift:
+    enabled: true


### PR DESCRIPTION
This adds an initial bootstrapping of ArgoCD to the bootstrap deployment. Instructions are included in the README and you are able to tell the bootstrap to just deploy the applications or Argo+Applications.

What this does:
- Provides way of installing ArgoCD as part of Bootstrap 
- Allows you to specify initial ArgoCD password
- Allows you to deploy ArgoCD + App of Apps together
- Allows you to specify list of known-hosts to add to ArgoCD

I'm thinking that OpenShift Auth + RBAC will be done as a follow up PR, but let me know if there are any other thoughts there.

cc/ @pabrahamsson @oybed @jacobsee 