### PR TITLE
Automatic deploy on push to master, part 2

### DIFF
--- a/applications/templates/application.yaml
+++ b/applications/templates/application.yaml
@@ -12,15 +12,15 @@ spec:
   source:
     path: {{ .path | default "." | quote }}
     repoURL: {{ .url | quote }}
-    targetRevision: {{ .ref | quote }}
-    {{- if (.helmValues) }}
+    targetRevision: {{ .ref | default "master" | quote }}
+    {{- if .helmValues }}
     helm:
       values: |-
         {{- range $key, $value := .helmValues }}
         {{ $key }}: {{ $value }}
         {{- end }}
     {{- end }}
-  {{- if (.diffIgnore )}}
+  {{- if .diffIgnore }}
   ignoreDifferences:
   {{- range .diffIgnore }}
   - group: {{ .group }}
@@ -30,7 +30,7 @@ spec:
       - {{ . }}
       {{- end }}
     {{- end }}
-  {{- end }} 
+  {{- end }}
   syncPolicy:
     automated:
       prune: true

--- a/applications/values.yaml
+++ b/applications/values.yaml
@@ -11,17 +11,8 @@ server: https://kubernetes.default.svc
 ##################
 
 applicationVersions:
-  frontend: &frontendVersion 308347520a1bc91ca2d4cdad668a6035e99d2a07
-  backend: &backendVersion master
   infinispan: &infinispanVersion 1.1.1.Final
-  git-api: &gitApiVersion ef3fa1e1fe9dbb6091a0561c776c896b57ba0de1
   launcher: &launcherVersion 3478f8caecf4198b73bdd3beb0efec42f322761a
-
-###########
-# Image tag
-###########
-imageTags:
-  backend: &backendImageTag latest
 
 ##################################
 # Application Template Definitions
@@ -31,16 +22,15 @@ applications:
 - name: omp-frontend
   url: https://github.com/rht-labs/open-management-portal-frontend.git
   path: deployment
-  ref: *frontendVersion
-  helmValues:
-    imageTag: *frontendVersion
 
 - name: omp-backend
   url: https://github.com/rht-labs/open-management-portal-backend.git
   path: deployment
-  ref: *backendVersion
-  helmValues:
-    imageTag: *backendImageTag
+  diffIgnore:
+  - group: apps.openshift.io
+    kind: DeploymentConfig
+    jsonPointers:
+    - /spec/template/spec/containers/0/image
 
 - name: infinispan-operator
   url: https://github.com/infinispan/infinispan-operator.git
@@ -50,9 +40,6 @@ applications:
 - name: git-api
   url: https://github.com/rht-labs/open-management-portal-git-api.git
   path: deployment
-  ref: *gitApiVersion
-  helmValues:
-    imageTag: *gitApiVersion
 
 - name: omp-launcher
   url: https://github.com/redhat-cop/tool-integrations.git

--- a/applications/values.yaml
+++ b/applications/values.yaml
@@ -22,6 +22,11 @@ applications:
 - name: omp-frontend
   url: https://github.com/rht-labs/open-management-portal-frontend.git
   path: deployment
+  diffIgnore:
+  - group: apps.openshift.io
+    kind: DeploymentConfig
+    jsonPointers:
+    - /spec/template/spec/containers/0/image
 
 - name: omp-backend
   url: https://github.com/rht-labs/open-management-portal-backend.git
@@ -40,6 +45,11 @@ applications:
 - name: git-api
   url: https://github.com/rht-labs/open-management-portal-git-api.git
   path: deployment
+  diffIgnore:
+  - group: apps.openshift.io
+    kind: DeploymentConfig
+    jsonPointers:
+    - /spec/template/spec/containers/0/image
 
 - name: omp-launcher
   url: https://github.com/redhat-cop/tool-integrations.git


### PR DESCRIPTION
This change will default to `master` for `ref` if no version is specified will also default to `latest` for the image tag (this is set in each application chart).
It will also add a `diffIgnore` for the image name when using ImageStreams to prevent a deployment loop in ArgoCD.

**Do not merge until the following PRs have been merged:**
- https://github.com/rht-labs/open-management-portal-git-api/pull/35
- https://github.com/rht-labs/open-management-portal-frontend/pull/75