### PR TITLE
Add helmValues to backend for passing versions through

### DIFF
--- a/applications/values.yaml
+++ b/applications/values.yaml
@@ -31,6 +31,9 @@ applications:
 - name: omp-backend
   url: https://github.com/rht-labs/open-management-portal-backend.git
   path: deployment
+  helmValues:
+    infinispanVersion: &infinispanVersion
+    launcherVersion: &launcherVersion
   diffIgnore:
   - group: apps.openshift.io
     kind: DeploymentConfig


### PR DESCRIPTION
The result of a call with Kevin a few moments ago - adding some helm values to the backend application definition so that it can populate its own configmap with them. We'll likely try to get fancy in the future with a data structure here that the backend configmap can iterate off of without having to know the names... but, preferring to start simple.