### PR TITLE
Add ignoreDifferences for babylon CRDs

### DIFF
--- a/applications/values.yaml
+++ b/applications/values.yaml
@@ -104,6 +104,11 @@ applications:
     namespace:
       create: false
       name: omp-babylon-operators
+  ignoreDifferences:
+  - group: apiextensions.k8s.io
+    kind: CustomResourceDefinition
+    jsonPointers:
+    - /spec/names/shortNames
 
 - name: poolboy
   url: https://github.com/pabrahamsson/poolboy.git
@@ -116,3 +121,8 @@ applications:
     namespace:
       create: false
       name: omp-babylon-operators
+  ignoreDifferences:
+  - group: apiextensions.k8s.io
+    kind: CustomResourceDefinition
+    jsonPointers:
+    - /spec/names/shortNames


### PR DESCRIPTION
The anarchy-operator and poolboy have some custom fields that we need ArgoCD to ignore