### PR TITLE
Enable anarchy route for Tower callbacks

### DIFF
--- a/applications/values.yaml
+++ b/applications/values.yaml
@@ -104,6 +104,8 @@ applications:
     namespace:
       create: false
       name: omp-babylon-operators
+    openshift:
+      enabled: true
   ignoreDifferences:
   - group: apiextensions.k8s.io
     kind: CustomResourceDefinition


### PR DESCRIPTION
This will create a route and is needed for Tower to callback to Anarchy with updates on job status