### PR TITLE
Add role to allow reading babylon and argo custom resources

### DIFF
--- a/bootstrap/kustomization.yaml
+++ b/bootstrap/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - ./resources/route.yaml
 - ./resources/argocd-dex-token.yaml
 - ./resources/omp-apps.yaml
+- ./resources/omp-cluster-reader.yaml
 patchesStrategicMerge:
 - dex-sa-patch.yaml
 - argocd-server-patch.yaml

--- a/bootstrap/resources/omp-cluster-reader.yaml
+++ b/bootstrap/resources/omp-cluster-reader.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: omp-cluster-reader
+  labels:
+    rbac.example.com/aggregate-to-cluster-reader: "true"
+rules:
+- apiGroups: ["argoproj.io","anarchy.gpte.redhat.com","gpte.redhat.com","poolboy.gpte.redhat.com"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]


### PR DESCRIPTION
This adds a clusterrole that will allow users to read custom resources created by babylon operators and argocd. I went the more restrictive route of not just giving read/list/watch * as I'm not sure we want everyone to be able to see everything. We can either relax or restrict this further as we see fit moving forward (i.e. do we want to restrict some babylon resources because they contain some sensitive information, etc.)

cc/ @pabrahamsson @jacobsee @oybed 